### PR TITLE
Non holy fish sorting function not divisible by 5

### DIFF
--- a/scripts/FishDataProvider.js
+++ b/scripts/FishDataProvider.js
@@ -58,3 +58,13 @@ export const soldierFish = () => {
         } 
     } return gruntFish
 }
+
+export const nonHolyFish = () => {
+    const peasantFish = []
+    for (const fish of fishCollection) {
+        if (fish.length % 5 !== 0 && fish.length % 3 !== 0) {
+            console.log(fish)
+           peasantFish.push(fish)
+        } 
+    } return peasantFish
+}

--- a/scripts/FishDataProvider.js
+++ b/scripts/FishDataProvider.js
@@ -39,6 +39,7 @@ export const useFish = () => {
     return fishCollection.slice()
 }
 
+// These exported functions provide a copy of objects discriminated the divisibility of the .length property.
 export const mostHolyFish = () => {
     const holyFish = []
     for (const fish of fishCollection) {
@@ -46,7 +47,7 @@ export const mostHolyFish = () => {
             console.log(fish)
             holyFish.push(fish)
         } 
-    } return holyFish
+    } return holyFish.slice()
 }
 
 export const soldierFish = () => {
@@ -56,7 +57,7 @@ export const soldierFish = () => {
             console.log(fish)
             gruntFish.push(fish)
         } 
-    } return gruntFish
+    } return gruntFish.slice()
 }
 
 export const nonHolyFish = () => {
@@ -66,5 +67,5 @@ export const nonHolyFish = () => {
             console.log(fish)
            peasantFish.push(fish)
         } 
-    } return peasantFish
+    } return peasantFish.slice()
 }

--- a/scripts/FishList.js
+++ b/scripts/FishList.js
@@ -1,5 +1,5 @@
 // imports functions and arrays from other JS files
-import {  useFish, mostHolyFish, soldierFish  } from './FishDataProvider.js';
+import {  useFish, mostHolyFish, soldierFish, nonHolyFish  } from './FishDataProvider.js';
 import {  Fish  } from './Fish.js';
 
 
@@ -13,13 +13,14 @@ export const FishList = () => {
     // This stores the fish objects whos lenth property is divisible by 3
     const theHolyFish = mostHolyFish()
     const armyFish = soldierFish()
-  
+    const peasantFish = nonHolyFish()
 
     // -OLD- This creates a variable that converts all its contents into a string.
     // let fishHTMLRepresentations = ""
 
     let holyFishHTMLRep = ""
     let soldierFishHTMLRep = ""
+    let nonHolyFishHTMLRep = ""
 
     // -OLD- uses the new variable fish to iterate over the copy of the fishCollection array inside of useFish(),
     // then passes each object through the Fish() function that extracts all properties of the objects in fishCollection
@@ -35,6 +36,11 @@ export const FishList = () => {
     for (const hardiest of armyFish) {
         soldierFishHTMLRep += Fish(hardiest)
     }
+
+    for (const workingClass of peasantFish) {
+        nonHolyFishHTMLRep += Fish(workingClass)
+    }
+    
     // -OLD- this inserts the string that is inside the varable fishHTMLRepresentations into the location specified by the contentElement variable.
     // contentElement.innerHTML += `
     //         ${fishHTMLRepresentations}
@@ -43,6 +49,7 @@ export const FishList = () => {
     contentElement.innerHTML += `
       ${holyFishHTMLRep}
       ${soldierFishHTMLRep}
+      ${nonHolyFishHTMLRep}
     `
 
   }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,6 @@
 
 
-import {   useFish  } from './FishDataProvider.js';
+import {   nonHolyFish, useFish  } from './FishDataProvider.js';
 import {  FishList  } from './FishList.js';
 
 // This places the copy of the array fishCollection into a variable allTheFish
@@ -14,3 +14,4 @@ const allTheFish = useFish()
 //this calls the function FishList that combines both FishDataProvider.js and Fish.js and renders them to HTML
 FishList()
 
+nonHolyFish()

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,6 +1,5 @@
 
-
-import {   nonHolyFish, useFish  } from './FishDataProvider.js';
+import {    useFish  } from './FishDataProvider.js';
 import {  FishList  } from './FishList.js';
 
 // This places the copy of the array fishCollection into a variable allTheFish
@@ -14,4 +13,3 @@ const allTheFish = useFish()
 //this calls the function FishList that combines both FishDataProvider.js and Fish.js and renders them to HTML
 FishList()
 
-nonHolyFish()


### PR DESCRIPTION
# Description
Adds a nonHolyFish() function that excludes all fish objects with length properties divisible by both 5 and 3. Fishlish.js updated to process nonHolyFish() in HTML and render them after soldierFish(). 
Housekeeping changes for readability.

## Type of change
Please delete options that are not relevant.

- [x ] New feature (non-breaking change which adds functionality)

# Testing Instructions

1. `git fetch --all`
2. `git checkout branch-name`
3. `serve`